### PR TITLE
Fix TPM_SLOT variable

### DIFF
--- a/new-disk-key.sh
+++ b/new-disk-key.sh
@@ -12,7 +12,7 @@ dd if=/dev/urandom of="$tmpdir/newkey.bin" bs=1 count=32
 
 # Kill the existing key
 echo "Removing old key..."
-cryptsetup luksKillSlot "$DISK" "TPM_SLOT" -d /keys/rootkey.bin
+cryptsetup luksKillSlot "$DISK" "${TPM_SLOT}" -d /keys/rootkey.bin
 
 # Seal the new key to the TPM
 echo "Sealing key to TPM..."


### PR DESCRIPTION
Fix use of the `TPM_SLOT` variable in `new-disk-key.sh` (missing `$`)